### PR TITLE
fix: use current SeaTemperatures.net location pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This custom integration for Home Assistant fetches sea temperatures directly fro
 ## Features
 
 - **Global Coverage**: Select coastal locations from around the world.
-- **Detailed Attributes**: Provides today's temperature alongside historical data (yesterday, last week, last year) and averages as attributes.
+- **Detailed Attributes**: Provides today's temperature alongside current site data such as yesterday, 10-year averages, and a 30-day chart. A `last_week` value is exposed only when it can be derived from the published 30-day series.
 - **Device per Place**: Creates a dedicated device in Home Assistant for each monitored location.
 - **Bundled Custom Card**: Displays current temperatures, 24h trend indicators (🌊/📈/📉), and a 30-day D3 historical area chart.
 - **Localization**: Supports English, German, Spanish, French, and Italian out of the box.
@@ -44,9 +44,8 @@ Configuration is done entirely through the Home Assistant UI.
 
 1.  Go to **Settings** -> **Devices & Services**.
 2.  Click **Add Integration** and search for "Sea Temperature".
-    1. **Step 1: Select Continent**: Choose the continent of your desired location.
-    2. **Step 2: Select Country**: Choose the country.
-    3. **Step 3: Select Place**: Choose the specific location/beach.
+    1. **Step 1: Search**: Search for the SeaTemperatures.net location you want.
+    2. **Step 2: Select Location**: Choose the matching result.
 3.  Click **Submit**.
 
 ### 2. Adding the Dashboard Card
@@ -89,7 +88,9 @@ For each configured place, the following sensor will be created:
 
 | Sensor          | Description                        | Attributes                                                                                                                            | Example Value |
 | :-------------- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------ | :------------ |
-| **Temperature** | The current sea temperature today. | `yesterday`, `last_week`, `last_year`, `date`, `average_min`, `average_max`, `average_avg`, `charts`, `continent`, `country`, `place` | `21.5`        |
+| **Temperature** | The current sea temperature today. | `yesterday`, `last_week` (when derivable from the 30-day chart), `date`, `average_min`, `average_max`, `average_avg`, `charts`, `continent`, `country`, `area`, `place`, `path` | `21.5`        |
+
+`last_year` is no longer published on the current SeaTemperatures.net location pages, so the integration does not invent it.
 
 ## Development
 

--- a/custom_components/seatemperatures/__init__.py
+++ b/custom_components/seatemperatures/__init__.py
@@ -8,8 +8,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
 from .api import SeaTemperatureAPI
-from .const import CONF_PLACE, CONF_PLACE_ID, DOMAIN
+from .const import (
+    CONF_AREA,
+    CONF_CONTINENT,
+    CONF_COUNTRY,
+    CONF_PATH,
+    CONF_PLACE,
+    CONF_PLACE_ID,
+    DOMAIN,
+)
 
 PLATFORMS = [Platform.SENSOR]
 SCAN_INTERVAL = timedelta(hours=2)  # Sea temperatures don't change frequently
@@ -88,21 +97,68 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate legacy config entries from place IDs to path-based locations."""
+    if entry.version > 2:
+        _LOGGER.error("Unsupported SeaTemperatures config entry version: %s", entry.version)
+        return False
+
+    if entry.version < 2:
+        _LOGGER.debug("Migrating SeaTemperatures entry %s from version %s", entry.entry_id, entry.version)
+
+        data = dict(entry.data)
+        location_path = data.get(CONF_PATH)
+        if not location_path:
+            place_id = data.get(CONF_PLACE_ID)
+            if not place_id:
+                _LOGGER.error(
+                    "SeaTemperatures entry %s has no place_id to migrate. Remove and re-add the integration.",
+                    entry.entry_id,
+                )
+                return False
+
+            location = await SeaTemperatureAPI(hass).get_location_by_place_id(place_id)
+            if location is None:
+                _LOGGER.error(
+                    "SeaTemperatures place_id %s could not be mapped to a current location path. Remove and re-add the integration.",
+                    place_id,
+                )
+                return False
+
+            data[CONF_PATH] = location[CONF_PATH]
+            data[CONF_PLACE] = location.get("name", data.get(CONF_PLACE, "Unknown"))
+            data[CONF_COUNTRY] = location.get(CONF_COUNTRY, data.get(CONF_COUNTRY, ""))
+            data[CONF_AREA] = location.get(CONF_AREA, data.get(CONF_AREA, ""))
+            data.setdefault(CONF_CONTINENT, data.get(CONF_CONTINENT, ""))
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data=data,
+            unique_id=data[CONF_PATH],
+            version=2,
+        )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Sea Temperature from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
     place_name = entry.data.get(CONF_PLACE, "Unknown")
-    place_id = entry.data.get(CONF_PLACE_ID)
+    location_path = entry.data.get(CONF_PATH)
+    location_key = entry.data.get(CONF_PLACE_ID) or location_path or entry.entry_id
 
     api = SeaTemperatureAPI(hass)
 
     async def async_update_data():
         """Fetch data from API."""
-        if not place_id:
-            raise UpdateFailed("No place ID configured.")
+        if not location_path:
+            raise UpdateFailed(
+                "No location path configured. Remove and re-add the integration."
+            )
 
-        data = await api.get_temperatures(place_id)
+        data = await api.get_temperatures(location_path)
         if not data:
             raise UpdateFailed(f"Failed to fetch data for place {place_name}")
 
@@ -111,7 +167,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        name=f"seatemperatures_{place_id}",
+        name=f"seatemperatures_{location_key}",
         update_method=async_update_data,
         update_interval=SCAN_INTERVAL,
     )

--- a/custom_components/seatemperatures/api.py
+++ b/custom_components/seatemperatures/api.py
@@ -2,14 +2,100 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+
 import aiohttp
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import API_URL_PLACES, API_URL_TEMPS
+from .const import (
+    API_URL_MAP_LOCATIONS,
+    API_URL_SEARCH,
+    BASE_URL,
+    DEFAULT_USER_AGENT,
+    DOMAIN,
+)
+from .parser import parse_location_page, validate_location_path
 
 _LOGGER = logging.getLogger(__name__)
+_MAP_LOCATIONS_CACHE = "map_locations_cache"
+
+
+def parse_search_results(data: Any) -> list[dict[str, str]]:
+    """Parse search endpoint results into normalized location dictionaries."""
+    if not isinstance(data, dict):
+        return []
+
+    results: list[dict[str, str]] = []
+    for item in data.get("results", []):
+        if not isinstance(item, dict):
+            continue
+
+        path = item.get("path")
+        name = item.get("name")
+        if not isinstance(path, str) or not isinstance(name, str):
+            continue
+
+        try:
+            normalized_path = validate_location_path(path)
+        except ValueError:
+            _LOGGER.debug("Ignoring search result with invalid path: %s", path)
+            continue
+
+        results.append(
+            {
+                "name": name,
+                "country": item.get("country", "")
+                if isinstance(item.get("country"), str)
+                else "",
+                "region": item.get("region", "")
+                if isinstance(item.get("region"), str)
+                else "",
+                "area": item.get("area", "")
+                if isinstance(item.get("area"), str)
+                else "",
+                "path": normalized_path,
+            }
+        )
+
+    return results
+
+
+def parse_map_locations(data: Any) -> dict[str, dict[str, str]]:
+    """Parse map-locations payload into a place_id -> location mapping."""
+    if isinstance(data, dict):
+        raw_locations = data.get("locations", [])
+    else:
+        raw_locations = data
+
+    if not isinstance(raw_locations, list):
+        return {}
+
+    mapping: dict[str, dict[str, str]] = {}
+    for item in raw_locations:
+        if not isinstance(item, list) or len(item) < 5:
+            continue
+
+        place_id, name, country, area, path = item[:5]
+        if not isinstance(place_id, str) or not isinstance(name, str):
+            continue
+        if not isinstance(path, str):
+            continue
+
+        try:
+            normalized_path = validate_location_path(path)
+        except ValueError:
+            _LOGGER.debug("Ignoring map location with invalid path: %s", path)
+            continue
+
+        mapping[place_id] = {
+            "name": name,
+            "country": country if isinstance(country, str) else "",
+            "area": area if isinstance(area, str) else "",
+            "path": normalized_path,
+        }
+
+    return mapping
 
 
 class SeaTemperatureAPI:
@@ -18,28 +104,75 @@ class SeaTemperatureAPI:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the API."""
         self.hass = hass
+        self._headers = {"User-Agent": DEFAULT_USER_AGENT}
 
-    async def get_places(self) -> dict[str, Any] | None:
-        """Fetch the places hierarchy (continents -> countries -> places)."""
+    async def search_locations(self, query: str) -> list[dict[str, str]] | None:
+        """Search SeaTemperatures locations by query string."""
+        if not query.strip():
+            return []
+
         session = async_get_clientsession(self.hass)
         try:
-            async with session.get(API_URL_PLACES) as response:
+            async with session.get(
+                API_URL_SEARCH,
+                params={"q": query.strip()},
+                headers=self._headers,
+            ) as response:
                 response.raise_for_status()
-                return await response.json()
+                return parse_search_results(await response.json())
         except (aiohttp.ClientError, TimeoutError) as err:
-            _LOGGER.error("Error fetching places data: %s", err)
+            _LOGGER.error("Error searching SeaTemperatures locations for %s: %s", query, err)
             return None
 
-    async def get_temperatures(self, place_id: str) -> dict[str, Any] | None:
-        """Fetch temperature data for a specific place_id."""
-        url = f"{API_URL_TEMPS}{place_id}"
+    async def get_location_by_place_id(self, place_id: str) -> dict[str, str] | None:
+        """Resolve a legacy place ID to a current path-based location."""
+        if not place_id:
+            return None
+
+        cache = await self._get_map_locations()
+        if cache is None:
+            return None
+
+        return cache.get(place_id)
+
+    async def get_temperatures(self, location_path: str) -> dict[str, Any] | None:
+        """Fetch temperature data for a specific location path."""
+        try:
+            normalized_path = validate_location_path(location_path)
+        except ValueError as err:
+            _LOGGER.error("Invalid SeaTemperatures path %s: %s", location_path, err)
+            return None
+
+        url = f"{BASE_URL}{normalized_path}"
         session = async_get_clientsession(self.hass)
         try:
-            async with session.get(url) as response:
+            async with session.get(url, headers=self._headers) as response:
                 response.raise_for_status()
-                return await response.json()
+                html = await response.text()
         except (aiohttp.ClientError, TimeoutError) as err:
             _LOGGER.error(
-                "Error fetching temperature data for place %s: %s", place_id, err
+                "Error fetching temperature data for path %s: %s",
+                normalized_path,
+                err,
             )
             return None
+
+        return parse_location_page(html).as_legacy_payload()
+
+    async def _get_map_locations(self) -> dict[str, dict[str, str]] | None:
+        """Fetch and cache the map-locations payload for legacy migration."""
+        domain_data = self.hass.data.setdefault(DOMAIN, {})
+        if _MAP_LOCATIONS_CACHE in domain_data:
+            return domain_data[_MAP_LOCATIONS_CACHE]
+
+        session = async_get_clientsession(self.hass)
+        try:
+            async with session.get(API_URL_MAP_LOCATIONS, headers=self._headers) as response:
+                response.raise_for_status()
+                mapping = parse_map_locations(await response.json())
+        except (aiohttp.ClientError, TimeoutError) as err:
+            _LOGGER.error("Error fetching SeaTemperatures map locations: %s", err)
+            return None
+
+        domain_data[_MAP_LOCATIONS_CACHE] = mapping
+        return mapping

--- a/custom_components/seatemperatures/config_flow.py
+++ b/custom_components/seatemperatures/config_flow.py
@@ -9,137 +9,132 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .api import SeaTemperatureAPI
 from .const import (
+    CONF_AREA,
     DOMAIN,
     CONF_CONTINENT,
     CONF_COUNTRY,
     CONF_PLACE,
-    CONF_PLACE_ID,
+    CONF_PATH,
 )
 
 _LOGGER = logging.getLogger(__name__)
+QUERY_FIELD = "query"
 
 
 class SeaTemperatureConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Sea Temperature."""
 
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-        self._places_data: dict[str, Any] | None = None
-        self._continents: list[str] = []
-        self._countries: list[str] = []
-        self._places: dict[str, Any] = {}
+        self._search_results: dict[str, dict[str, str]] = {}
         self._data: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step (fetch places and select continent)."""
+        """Search for a location to configure."""
         api = SeaTemperatureAPI(self.hass)
-
-        if self._places_data is None:
-            self._places_data = await api.get_places()
-            if not self._places_data:
-                return self.async_abort(reason="cannot_connect")
-
-            # Extract continents from flat list
-            self._continents = sorted(
-                list(set(p["continent_name"] for p in self._places_data))
-            )
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            self._data[CONF_CONTINENT] = user_input[CONF_CONTINENT]
-            return await self.async_step_country()
+            query = user_input[QUERY_FIELD].strip()
+            if not query:
+                errors["base"] = "invalid_query"
+            else:
+                results = await api.search_locations(query)
+                if results is None:
+                    return self.async_abort(reason="cannot_connect")
+
+                self._search_results = self._build_result_map(results)
+                self._data[QUERY_FIELD] = query
+                if self._search_results:
+                    return await self.async_step_select()
+
+                errors["base"] = "no_results"
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_CONTINENT): vol.In(self._continents),
+                vol.Required(
+                    QUERY_FIELD,
+                    default=user_input[QUERY_FIELD] if user_input else "",
+                ): str,
             }
         )
 
         return self.async_show_form(
             step_id="user",
             data_schema=data_schema,
+            errors=errors,
         )
 
-    async def async_step_country(
+    async def async_step_select(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the country selection step."""
-        continent = self._data[CONF_CONTINENT]
-
-        # Always extract countries to handle back navigation correctly
-        self._countries = sorted(
-            list(
-                set(
-                    p["country_name"]
-                    for p in self._places_data
-                    if p["continent_name"] == continent
-                )
-            )
-        )
+        """Select one of the search results."""
+        if not self._search_results:
+            return await self.async_step_user()
 
         if user_input is not None:
-            self._data[CONF_COUNTRY] = user_input[CONF_COUNTRY]
-            return await self.async_step_place()
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_COUNTRY): vol.In(self._countries),
-            }
-        )
-
-        return self.async_show_form(
-            step_id="country",
-            data_schema=data_schema,
-        )
-
-    async def async_step_place(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the place selection step."""
-        continent = self._data[CONF_CONTINENT]
-        country = self._data[CONF_COUNTRY]
-
-        # Always extract places for selected country/continent
-        places_list = [
-            p
-            for p in self._places_data
-            if p["continent_name"] == continent and p["country_name"] == country
-        ]
-        self._places = {p["place_name"]: p["id"] for p in places_list}
-        _LOGGER.debug(
-            "Populated self._places for %s, %s: %s",
-            continent,
-            country,
-            self._places,
-        )
-
-        if user_input is not None:
-            place_name = user_input[CONF_PLACE]
-            place_id = self._places[place_name]
+            location = self._search_results[user_input[CONF_PLACE]]
+            await self.async_set_unique_id(location[CONF_PATH])
+            self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
-                title=f"{place_name} Sea Temperature",
+                title=f"{location[CONF_PLACE]} Sea Temperature",
                 data={
-                    CONF_CONTINENT: continent,
-                    CONF_COUNTRY: country,
-                    CONF_PLACE: place_name,
-                    CONF_PLACE_ID: str(place_id),
+                    CONF_CONTINENT: location.get(CONF_CONTINENT, ""),
+                    CONF_COUNTRY: location.get(CONF_COUNTRY, ""),
+                    CONF_AREA: location.get(CONF_AREA, ""),
+                    CONF_PLACE: location[CONF_PLACE],
+                    CONF_PATH: location[CONF_PATH],
                 },
             )
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_PLACE): vol.In(
-                    sorted(list(self._places.keys())) if self._places else []
-                ),
+                vol.Required(CONF_PLACE): vol.In(list(self._search_results.keys())),
             }
         )
 
         return self.async_show_form(
-            step_id="place",
+            step_id="select",
             data_schema=data_schema,
+            description_placeholders={QUERY_FIELD: self._data.get(QUERY_FIELD, "")},
             last_step=True,
         )
+
+    def _build_result_map(
+        self, results: list[dict[str, str]]
+    ) -> dict[str, dict[str, str]]:
+        """Build a stable label -> location mapping for flow selection."""
+        mapped_results: dict[str, dict[str, str]] = {}
+        for result in results:
+            label = self._format_result_label(result)
+            if label in mapped_results:
+                label = f"{label} [{result[CONF_PATH]}]"
+
+            mapped_results[label] = {
+                CONF_CONTINENT: result.get("region", ""),
+                CONF_COUNTRY: result.get("country", ""),
+                CONF_AREA: result.get("area", ""),
+                CONF_PLACE: result["name"],
+                CONF_PATH: result["path"],
+            }
+
+        _LOGGER.debug("Search results mapped for selection: %s", mapped_results)
+        return mapped_results
+
+    @staticmethod
+    def _format_result_label(result: dict[str, str]) -> str:
+        """Format a search result for display in the config flow."""
+        details = result.get("area") or ", ".join(
+            part
+            for part in (result.get("country"), result.get("region"))
+            if part
+        )
+        if details:
+            return f"{result['name']} ({details})"
+
+        return result["name"]

--- a/custom_components/seatemperatures/const.py
+++ b/custom_components/seatemperatures/const.py
@@ -4,12 +4,15 @@ DOMAIN = "seatemperatures"
 
 CONF_CONTINENT = "continent"
 CONF_COUNTRY = "country"
+CONF_AREA = "area"
 CONF_PLACE = "place"
 CONF_PLACE_ID = "place_id"
+CONF_PATH = "path"
 
 BASE_URL = "https://seatemperatures.net"
-API_URL_PLACES = f"{BASE_URL}/_data/places.json"
-API_URL_TEMPS = f"{BASE_URL}/api/temps?placeId="
+API_URL_MAP_LOCATIONS = f"{BASE_URL}/api/map-locations.json"
+API_URL_SEARCH = f"{BASE_URL}/api/search/"
+DEFAULT_USER_AGENT = "HomeAssistant seatemperatures integration"
 
 # Sensors
 SENSOR_TODAY = "today"

--- a/custom_components/seatemperatures/parser.py
+++ b/custom_components/seatemperatures/parser.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from html import unescape
+import json
+import logging
+import posixpath
+import re
+from typing import Any
+from urllib.parse import unquote, urlsplit
+
+_LOGGER = logging.getLogger(__name__)
+
+_CHART_PAYLOAD_RE = re.compile(
+    r'<script[^>]*data-sea-curve-payload[^>]*>(.*?)</script>',
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_DATE_RE = re.compile(r">\s*([A-Za-z]+ \d{1,2}(?:st|nd|rd|th) [A-Za-z]+, \d{4})\s*<")
+
+
+@dataclass(slots=True)
+class SeaTemperatureData:
+    """Structured data parsed from a location page."""
+
+    date: str | None = None
+    today: float | None = None
+    yesterday: float | None = None
+    last_week: float | None = None
+    last_year: float | None = None
+    average_min: float | None = None
+    average_max: float | None = None
+    average_avg: float | None = None
+    trend_labels: list[str] | None = None
+    trend_temps_c: list[float] | None = None
+
+    def as_legacy_payload(self) -> dict[str, Any]:
+        """Return the legacy payload shape expected by the integration."""
+        payload: dict[str, Any] = {"sst": {}}
+        sst: dict[str, Any] = payload["sst"]
+
+        if self.date is not None:
+            payload["date"] = self.date
+
+        for key in ("today", "yesterday", "last_week", "last_year"):
+            value = getattr(self, key)
+            if value is not None:
+                sst[key] = value
+
+        average = {
+            key: value
+            for key, value in {
+                "min": self.average_min,
+                "max": self.average_max,
+                "avg": self.average_avg,
+            }.items()
+            if value is not None
+        }
+        if average:
+            sst["average"] = average
+
+        if self.trend_labels and self.trend_temps_c:
+            payload["charts"] = {
+                "last_thirty": {
+                    "labels": self.trend_labels,
+                    "series": self.trend_temps_c,
+                }
+            }
+
+        return payload
+
+
+def validate_location_path(path: str) -> str:
+    """Validate and normalize a SeaTemperatures location path."""
+    if not isinstance(path, str) or not path.strip():
+        raise ValueError("Location path is empty")
+
+    parts = urlsplit(path.strip())
+    if parts.scheme or parts.netloc or parts.query or parts.fragment:
+        raise ValueError("Location path must be a relative path")
+
+    decoded_path = unquote(parts.path)
+    if not decoded_path.startswith("/"):
+        raise ValueError("Location path must start with '/'")
+
+    if "\\" in decoded_path:
+        raise ValueError("Location path must not contain backslashes")
+
+    segments = [segment for segment in decoded_path.split("/") if segment]
+    if not segments:
+        raise ValueError("Location path must contain at least one segment")
+
+    if any(segment in {".", ".."} for segment in segments):
+        raise ValueError("Location path must not contain path traversal")
+
+    normalized = posixpath.normpath("/" + "/".join(segments))
+    return f"{normalized}/"
+
+
+def parse_location_page(html: str) -> SeaTemperatureData:
+    """Parse a SeaTemperatures location page into structured data."""
+    data = SeaTemperatureData(
+        date=_parse_page_date(html),
+        today=_extract_summary_value(html, "Today"),
+        yesterday=_extract_summary_value(html, "Yesterday"),
+        average_avg=_extract_summary_value(html, "10-year average"),
+        average_min=_extract_float(
+            html, r'low temperature of\s*<span[^>]+data-c="([^"]+)"'
+        ),
+        average_max=_extract_float(html, r'high of\s*<span[^>]+data-c="([^"]+)"'),
+    )
+
+    trend_labels, trend_temps_c, last_week = _parse_trend_chart(html)
+    data.trend_labels = trend_labels
+    data.trend_temps_c = trend_temps_c
+    data.last_week = last_week
+
+    if not any(
+        value is not None
+        for value in (
+            data.today,
+            data.yesterday,
+            data.average_avg,
+            data.average_min,
+            data.average_max,
+            data.last_week,
+        )
+    ):
+        _LOGGER.warning("Parsed SeaTemperatures page without any temperature values")
+
+    return data
+
+
+def _extract_summary_value(html: str, label: str) -> float | None:
+    pattern = (
+        rf">\s*{re.escape(label)}\s*</p>\s*<p[^>]*>\s*"
+        r'<span[^>]+data-c="([^"]+)"'
+    )
+    return _extract_float(html, pattern)
+
+
+def _extract_float(html: str, pattern: str) -> float | None:
+    match = re.search(pattern, html, flags=re.IGNORECASE | re.DOTALL)
+    if match is None:
+        return None
+
+    try:
+        return float(match.group(1))
+    except (TypeError, ValueError):
+        _LOGGER.debug("Failed to parse float from %s", match.group(1))
+        return None
+
+
+def _parse_page_date(html: str) -> str | None:
+    match = _DATE_RE.search(html)
+    if match is None:
+        return None
+
+    page_date = re.sub(r"(\d+)(st|nd|rd|th)", r"\1", match.group(1))
+    try:
+        return datetime.strptime(page_date, "%A %d %B, %Y").date().isoformat()
+    except ValueError:
+        _LOGGER.debug("Failed to parse page date from %s", page_date)
+        return None
+
+
+def _parse_trend_chart(html: str) -> tuple[list[str] | None, list[float] | None, float | None]:
+    match = _CHART_PAYLOAD_RE.search(html)
+    if match is None:
+        return None, None, None
+
+    try:
+        chart_payload = json.loads(unescape(match.group(1)))
+    except json.JSONDecodeError as err:
+        _LOGGER.warning("Failed to parse SeaTemperatures chart payload: %s", err)
+        return None, None, None
+
+    if not isinstance(chart_payload, dict):
+        return None, None, None
+
+    raw_times = chart_payload.get("times")
+    raw_temps = chart_payload.get("tempsC")
+    if not isinstance(raw_times, list) or not isinstance(raw_temps, list):
+        return None, None, None
+
+    points: list[tuple[int, float]] = []
+    for raw_time, raw_temp in zip(raw_times, raw_temps, strict=False):
+        try:
+            points.append((int(raw_time), float(raw_temp)))
+        except (TypeError, ValueError):
+            continue
+
+    if not points:
+        return None, None, None
+
+    points.sort(key=lambda point: point[0])
+    labels = [datetime.fromtimestamp(ts, UTC).strftime("%m-%d") for ts, _ in points]
+    temps = [temp for _, temp in points]
+
+    latest_timestamp = points[-1][0]
+    # The current site no longer exposes dedicated last-week/last-year values.
+    # We only derive last_week when the daily chart includes the exact day.
+    last_week_timestamp = latest_timestamp - 7 * 24 * 60 * 60
+    last_week = next(
+        (temp for timestamp, temp in points if timestamp == last_week_timestamp),
+        None,
+    )
+
+    return labels, temps, last_week

--- a/custom_components/seatemperatures/sensor.py
+++ b/custom_components/seatemperatures/sensor.py
@@ -20,7 +20,8 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import slugify
 
-from .const import CONF_PLACE, CONF_PLACE_ID, DOMAIN
+from .const import BASE_URL, CONF_AREA, CONF_PATH, CONF_PLACE, CONF_PLACE_ID, DOMAIN
+from .parser import validate_location_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,14 +86,16 @@ class SeaTemperatureSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self._entry = entry
         self._place_name = entry.data.get(CONF_PLACE, "Unknown")
-        self._place_id = entry.data[CONF_PLACE_ID]
+        self._location_key = entry.data.get(CONF_PLACE_ID) or entry.data.get(CONF_PATH)
+        if self._location_key is None:
+            self._location_key = self._place_name
 
         # Set friendly name
         self._attr_name = "Temperature"
 
         place_prefix = slugify(self._place_name)
 
-        self._attr_unique_id = f"{DOMAIN}_{self._place_id}_{description.key}"
+        self._attr_unique_id = f"{DOMAIN}_{self._location_key}_{description.key}"
         self.entity_id = f"sensor.{DOMAIN}_{place_prefix}_{description.key}"
 
     @property
@@ -143,29 +146,25 @@ class SeaTemperatureSensor(CoordinatorEntity, SensorEntity):
 
         attrs["continent"] = self._entry.data.get("continent", "")
         attrs["country"] = self._entry.data.get("country", "")
+        attrs["area"] = self._entry.data.get(CONF_AREA, "")
         attrs["place"] = self._place_name
+        attrs["path"] = self._entry.data.get(CONF_PATH, "")
 
         return attrs if attrs else None
 
     @property
     def device_info(self):
         """Return device information."""
-        continent = self._entry.data.get("continent", "")
-        country = self._entry.data.get("country", "")
-        place = self._entry.data.get("place", "")
-
-        url = "https://seatemperatures.net"
-        if continent and country and place:
-            import re
-
-            def slugify(text: str) -> str:
-                text = text.lower().replace("&", "and").replace("/", " and ")
-                return re.sub(r"[^a-z0-9]+", "-", text).strip("-")
-
-            url = f"{url}/{slugify(continent)}/{slugify(country)}/{slugify(place)}/"
+        url = BASE_URL
+        location_path = self._entry.data.get(CONF_PATH)
+        if location_path:
+            try:
+                url = f"{BASE_URL}{validate_location_path(location_path)}"
+            except ValueError:
+                _LOGGER.debug("Invalid configuration URL path for %s", self._place_name)
 
         return {
-            "identifiers": {(DOMAIN, self._place_id)},
+            "identifiers": {(DOMAIN, self._location_key)},
             "name": self._place_name,
             "manufacturer": "Sea Temperatures",
             "model": "Sea Temperature Monitor",

--- a/custom_components/seatemperatures/tests/fixtures/copenhagen.html
+++ b/custom_components/seatemperatures/tests/fixtures/copenhagen.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <h2 class="text-2xl font-semibold text-primary">Thursday 21st May, 2026</h2>
+    <div class="mt-5 grid gap-4 sm:grid-cols-3">
+      <div>
+        <p class="text-lg font-semibold text-primary">Today</p>
+        <p><span data-c="11.83">11.83° C</span></p>
+      </div>
+      <div>
+        <p class="text-lg font-semibold text-primary">Yesterday</p>
+        <p><span data-c="11.7">11.7° C</span></p>
+      </div>
+      <div>
+        <p class="text-lg font-semibold text-primary">10-year average</p>
+        <p><span data-c="12.126000000000001">12.13° C</span></p>
+      </div>
+    </div>
+    <p>
+      The average sea temperature for Copenhagen on May 21 over the last 10 years is
+      <span data-c="12.126000000000001">12.13° C</span>, with a low temperature of
+      <span data-c="10.85">10.85° C</span> and a high of <span data-c="13.67">13.67° C</span>.
+    </p>
+    <script type="application/json" data-sea-curve-payload>{"start":1776859200,"end":1779364800,"times":[1776859200,1776945600,1777032000,1777118400,1777204800,1777291200,1777377600,1777464000,1777550400,1777636800,1777723200,1777809600,1777896000,1777982400,1778068800,1778155200,1778241600,1778328000,1778414400,1778500800,1778587200,1778673600,1778760000,1778846400,1778932800,1779019200,1779105600,1779192000,1779278400,1779364800],"tempsC":[7.46,7.22,7.52,7.99,8.08,8.27,8.48,8.73,8.86,9.24,9.57,9.9,10.35,9.11,9.24,9.34,9.49,9.58,9.67,9.81,9.99,10.13,10.31,10.64,10.82,10.73,10.78,11.34,11.7,11.83],"layout":{"padLeft":0,"padTop":28,"padRight":0,"padBottom":28,"viewW":1000,"viewH":280}}</script>
+  </body>
+</html>

--- a/custom_components/seatemperatures/tests/fixtures/miami_beach.html
+++ b/custom_components/seatemperatures/tests/fixtures/miami_beach.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <h2 class="text-2xl font-semibold text-primary">Thursday 21st May, 2026</h2>
+    <p class="mt-1 flex items-center gap-1.5 text-sm text-foreground-muted">Florida, United States</p>
+    <div class="mt-5 grid gap-4 sm:grid-cols-3">
+      <div>
+        <p class="text-lg font-semibold text-primary">Today</p>
+        <p><span data-c="27.97">27.97° C</span></p>
+      </div>
+      <div>
+        <p class="text-lg font-semibold text-primary">Yesterday</p>
+        <p><span data-c="27.95">27.95° C</span></p>
+      </div>
+      <div>
+        <p class="text-lg font-semibold text-primary">10-year average</p>
+        <p><span data-c="27.784999999999997">27.78° C</span></p>
+      </div>
+    </div>
+    <p>
+      The average sea temperature for Miami Beach on May 21 over the last 10 years is
+      <span data-c="27.784999999999997">27.78° C</span>, with a low temperature of
+      <span data-c="26.47">26.47° C</span> and a high of <span data-c="28.71">28.71° C</span>.
+    </p>
+    <script type="application/json" data-sea-curve-payload>{"start":1776859200,"end":1779364800,"times":[1776859200,1776945600,1777032000,1777118400,1777204800,1777291200,1777377600,1777464000,1777550400,1777636800,1777723200,1777809600,1777896000,1777982400,1778068800,1778155200,1778241600,1778328000,1778414400,1778500800,1778587200,1778673600,1778760000,1778846400,1778932800,1779019200,1779105600,1779192000,1779278400,1779364800],"tempsC":[26.42,26.18,26.29,26.2,26.18,26.22,26.32,26.51,26.73,26.9,26.85,26.74,26.76,27.03,27.12,27.17,27.2,27.24,27.2,27.29,27.34,27.37,28.5,28.24,28.23,28.22,28.17,27.96,27.95,27.97],"layout":{"padLeft":0,"padTop":28,"padRight":0,"padBottom":28,"viewW":1000,"viewH":280}}</script>
+  </body>
+</html>

--- a/custom_components/seatemperatures/tests/test_api.py
+++ b/custom_components/seatemperatures/tests/test_api.py
@@ -1,79 +1,306 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
-from custom_components.seatemperatures.api import SeaTemperatureAPI
+from custom_components.seatemperatures import async_migrate_entry
+from custom_components.seatemperatures.api import (
+    SeaTemperatureAPI,
+    parse_map_locations,
+    parse_search_results,
+)
+from custom_components.seatemperatures.config_flow import QUERY_FIELD, SeaTemperatureConfigFlow
+from custom_components.seatemperatures.const import (
+    CONF_AREA,
+    CONF_CONTINENT,
+    CONF_COUNTRY,
+    CONF_PATH,
+    CONF_PLACE,
+    CONF_PLACE_ID,
+)
+from custom_components.seatemperatures.parser import (
+    parse_location_page,
+    validate_location_path,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
 def mock_hass():
     """Mock Home Assistant object."""
-    return AsyncMock()
+    hass = AsyncMock()
+    hass.data = {}
+    hass.config_entries = SimpleNamespace(async_update_entry=MagicMock())
+    return hass
 
 
-@pytest.mark.asyncio
-async def test_get_places(mock_hass):
-    """Test getting places from API."""
+def load_fixture(name: str) -> str:
+    """Load an HTML fixture by name."""
+    return (FIXTURES_DIR / name).read_text(encoding="utf-8")
+
+
+async def test_parse_location_page_from_copenhagen_fixture() -> None:
+    """Parse a standard location page fixture."""
+    data = parse_location_page(load_fixture("copenhagen.html"))
+
+    assert data.date == "2026-05-21"
+    assert data.today == pytest.approx(11.83)
+    assert data.yesterday == pytest.approx(11.7)
+    assert data.average_avg == pytest.approx(12.126000000000001)
+    assert data.average_min == pytest.approx(10.85)
+    assert data.average_max == pytest.approx(13.67)
+    assert data.last_week == pytest.approx(10.31)
+    assert data.trend_labels is not None
+    assert data.trend_labels[0] == "04-22"
+    assert data.trend_labels[-1] == "05-21"
+    assert data.trend_temps_c is not None
+    assert data.trend_temps_c[-1] == pytest.approx(11.83)
+
+
+async def test_parse_location_page_is_not_location_specific() -> None:
+    """Parse a second fixture to prove the parser is generic."""
+    data = parse_location_page(load_fixture("miami_beach.html"))
+
+    assert data.today == pytest.approx(27.97)
+    assert data.yesterday == pytest.approx(27.95)
+    assert data.average_avg == pytest.approx(27.784999999999997)
+    assert data.average_min == pytest.approx(26.47)
+    assert data.average_max == pytest.approx(28.71)
+    assert data.last_week == pytest.approx(28.5)
+
+
+async def test_parse_location_page_tolerates_missing_values() -> None:
+    """Missing values should produce None instead of crashing."""
+    data = parse_location_page("<html><body><h1>No chart</h1></body></html>")
+
+    assert data.today is None
+    assert data.yesterday is None
+    assert data.average_avg is None
+    assert data.average_min is None
+    assert data.average_max is None
+    assert data.last_week is None
+    assert data.trend_labels is None
+    assert data.trend_temps_c is None
+
+
+async def test_parse_location_page_tolerates_malformed_chart_json(caplog: pytest.LogCaptureFixture) -> None:
+    """Malformed chart JSON should be ignored with a warning."""
+    html = """
+    <html><body>
+      <p>Today</p><p><span data-c="15.5">15.5</span></p>
+      <script type="application/json" data-sea-curve-payload>{broken json</script>
+    </body></html>
+    """
+
+    data = parse_location_page(html)
+
+    assert data.today == pytest.approx(15.5)
+    assert data.trend_labels is None
+    assert "Failed to parse SeaTemperatures chart payload" in caplog.text
+
+
+async def test_validate_location_path() -> None:
+    """Location paths should be normalized and validated."""
+    assert (
+        validate_location_path("/north-america/united-states/miami-beach")
+        == "/north-america/united-states/miami-beach/"
+    )
+
+    with pytest.raises(ValueError):
+        validate_location_path("https://seatemperatures.net/europe/denmark/copenhagen/")
+
+    with pytest.raises(ValueError):
+        validate_location_path("/../../etc/passwd")
+
+
+async def test_parse_search_results() -> None:
+    """Search results should be normalized into path-based location records."""
+    data = {
+        "results": [
+            {
+                "name": "Copenhagen",
+                "country": "Denmark",
+                "region": "Europe",
+                "path": "/europe/denmark/copenhagen/",
+                "area": "Denmark, Europe",
+            },
+            {"name": "Broken", "path": "https://example.com/not-allowed"},
+        ]
+    }
+
+    results = parse_search_results(data)
+
+    assert results == [
+        {
+            "name": "Copenhagen",
+            "country": "Denmark",
+            "region": "Europe",
+            "area": "Denmark, Europe",
+            "path": "/europe/denmark/copenhagen/",
+        }
+    ]
+
+
+async def test_parse_map_locations() -> None:
+    """Legacy map-locations payload should support place_id migration."""
+    data = {
+        "locations": [
+            [
+                "sea-1",
+                "Ain El Turk",
+                "Algeria",
+                "",
+                "/africa/algeria/ain-el-turk/",
+                35.7438,
+                -0.7693,
+                19.1,
+            ],
+            ["broken"],
+        ]
+    }
+
+    results = parse_map_locations(data)
+
+    assert results == {
+        "sea-1": {
+            "name": "Ain El Turk",
+            "country": "Algeria",
+            "area": "",
+            "path": "/africa/algeria/ain-el-turk/",
+        }
+    }
+
+
+async def test_get_temperatures_from_location_page(mock_hass) -> None:
+    """The API should fetch HTML and return the legacy payload shape."""
     api = SeaTemperatureAPI(mock_hass)
-
-    mock_data = {"Europe": {"Spain": [{"id": 123, "name": "Ibiza", "slug": "ibiza"}]}}
+    html = load_fixture("copenhagen.html")
 
     with patch(
         "custom_components.seatemperatures.api.async_get_clientsession"
     ) as mock_session:
         mock_response = AsyncMock()
-        mock_response.json.return_value = mock_data
+        mock_response.text.return_value = html
         mock_response.raise_for_status = MagicMock()
+        mock_session.return_value.get.return_value.__aenter__.return_value = mock_response
 
-        # Async context manager mock setup
-        mock_session.return_value.get.return_value.__aenter__.return_value = (
-            mock_response
-        )
+        result = await api.get_temperatures("/europe/denmark/copenhagen/")
 
-        result = await api.get_places()
-        assert result == mock_data
+    assert result is not None
+    assert result["date"] == "2026-05-21"
+    assert result["sst"]["today"] == pytest.approx(11.83)
+    assert result["sst"]["yesterday"] == pytest.approx(11.7)
+    assert result["sst"]["last_week"] == pytest.approx(10.31)
+    assert result["sst"]["average"]["avg"] == pytest.approx(12.126000000000001)
+    assert result["charts"]["last_thirty"]["labels"][-1] == "05-21"
 
 
-@pytest.mark.asyncio
-async def test_get_temperatures(mock_hass):
-    """Test getting temperatures from API including date attribute coverage."""
+async def test_get_location_by_place_id_uses_map_locations(mock_hass) -> None:
+    """Legacy IDs should resolve through map-locations data."""
     api = SeaTemperatureAPI(mock_hass)
-
-    mock_data = {
-        "date": "2026-03-13",
-        "sst": {
-            "today": 17.25,
-            "yesterday": 17.26,
-            "last_week": 16.17,
-            "last_year": 16.25,
-            "average": {"min": 14.71, "max": 16.25, "avg": 15.422999999999998},
-        },
-        "charts": {
-            "last_thirty": {
-                "labels": ["03-12", "03-13"],
-                "series": [17.26, 17.25],
-            }
-        },
+    payload = {
+        "locations": [["canonical-36", "Boumerdas", "Algeria", "Boumerdes", "/africa/algeria/boumerdas/"]]
     }
 
     with patch(
         "custom_components.seatemperatures.api.async_get_clientsession"
     ) as mock_session:
         mock_response = AsyncMock()
-        mock_response.json.return_value = mock_data
+        mock_response.json.return_value = payload
         mock_response.raise_for_status = MagicMock()
+        mock_session.return_value.get.return_value.__aenter__.return_value = mock_response
 
-        mock_session.return_value.get.return_value.__aenter__.return_value = (
-            mock_response
+        result = await api.get_location_by_place_id("canonical-36")
+
+    assert result == {
+        "name": "Boumerdas",
+        "country": "Algeria",
+        "area": "Boumerdes",
+        "path": "/africa/algeria/boumerdas/",
+    }
+
+
+async def test_config_flow_stores_path_based_location(mock_hass) -> None:
+    """Config flow should store location metadata including the path."""
+    flow = SeaTemperatureConfigFlow()
+    flow.hass = mock_hass
+
+    search_results = [
+        {
+            "name": "Miami Beach",
+            "country": "United States",
+            "region": "North America",
+            "area": "Florida, United States",
+            "path": "/north-america/united-states/miami-beach/",
+        }
+    ]
+
+    with patch.object(SeaTemperatureAPI, "search_locations", AsyncMock(return_value=search_results)):
+        user_result = await flow.async_step_user({QUERY_FIELD: "miami beach"})
+
+    assert user_result["type"] == "form"
+    assert user_result["step_id"] == "select"
+
+    with patch.object(flow, "async_set_unique_id", AsyncMock()), patch.object(
+        flow, "_abort_if_unique_id_configured", MagicMock()
+    ):
+        select_result = await flow.async_step_select(
+            {CONF_PLACE: "Miami Beach (Florida, United States)"}
         )
 
-        result = await api.get_temperatures("123")
+    assert select_result["type"] == "create_entry"
+    assert select_result["data"] == {
+        CONF_CONTINENT: "North America",
+        CONF_COUNTRY: "United States",
+        CONF_AREA: "Florida, United States",
+        CONF_PLACE: "Miami Beach",
+        CONF_PATH: "/north-america/united-states/miami-beach/",
+    }
 
-        # Verify result contains the mock data layout including date and nested average
-        assert result == mock_data
-        assert "date" in result
-        assert result["date"] == "2026-03-13"
-        assert result["sst"]["today"] == 17.25
-        assert result["sst"]["average"]["avg"] == 15.422999999999998
-        assert "charts" in result
-        assert "last_thirty" in result["charts"]
-        assert result["charts"]["last_thirty"]["labels"] == ["03-12", "03-13"]
+
+async def test_async_migrate_entry_from_place_id(mock_hass) -> None:
+    """Legacy config entries should migrate from place_id to path."""
+    entry = SimpleNamespace(
+        version=1,
+        entry_id="entry-1",
+        data={CONF_PLACE_ID: "sea-1", CONF_PLACE: "Legacy Name"},
+    )
+
+    with patch.object(
+        SeaTemperatureAPI,
+        "get_location_by_place_id",
+        AsyncMock(
+            return_value={
+                "name": "Ain El Turk",
+                "country": "Algeria",
+                "area": "",
+                "path": "/africa/algeria/ain-el-turk/",
+            }
+        ),
+    ):
+        migrated = await async_migrate_entry(mock_hass, entry)
+
+    assert migrated is True
+    mock_hass.config_entries.async_update_entry.assert_called_once()
+    _, kwargs = mock_hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"][CONF_PLACE] == "Ain El Turk"
+    assert kwargs["data"][CONF_COUNTRY] == "Algeria"
+    assert kwargs["data"][CONF_PATH] == "/africa/algeria/ain-el-turk/"
+    assert kwargs["unique_id"] == "/africa/algeria/ain-el-turk/"
+    assert kwargs["version"] == 2
+
+
+async def test_async_migrate_entry_fails_when_place_id_cannot_be_mapped(mock_hass) -> None:
+    """Migration should fail cleanly if a legacy ID no longer resolves."""
+    entry = SimpleNamespace(version=1, entry_id="entry-2", data={CONF_PLACE_ID: "missing"})
+
+    with patch.object(SeaTemperatureAPI, "get_location_by_place_id", AsyncMock(return_value=None)):
+        migrated = await async_migrate_entry(mock_hass, entry)
+
+    assert migrated is False
+    mock_hass.config_entries.async_update_entry.assert_not_called()

--- a/custom_components/seatemperatures/translations/de.json
+++ b/custom_components/seatemperatures/translations/de.json
@@ -2,22 +2,15 @@
   "config": {
     "step": {
       "user": {
-        "title": "Kontinent auswählen",
-        "description": "Bitte wählen Sie den Kontinent für das Gebiet aus, das Sie überwachen möchten.",
+        "title": "Ort suchen",
+        "description": "Suchen Sie auf SeaTemperatures.net nach dem Ort, den Sie überwachen möchten.",
         "data": {
-          "continent": "Kontinent"
+          "query": "Suche"
         }
       },
-      "country": {
-        "title": "Land auswählen",
-        "description": "Bitte wählen Sie das Land aus, in dem sich das Gebiet befindet.",
-        "data": {
-          "country": "Land"
-        }
-      },
-      "place": {
+      "select": {
         "title": "Ort auswählen",
-        "description": "Bitte wählen Sie den Ort aus, den Sie überwachen möchten.",
+        "description": "Wählen Sie das passende Ergebnis für \"{query}\" aus.",
         "data": {
           "place": "Ort"
         }
@@ -25,6 +18,8 @@
     },
     "error": {
       "cannot_connect": "Verbindung zu seatemperatures.net fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung.",
+      "invalid_query": "Geben Sie einen Ort für die Suche ein.",
+      "no_results": "Keine passenden Orte auf SeaTemperatures.net gefunden.",
       "unknown": "Unerwarteter Fehler."
     },
     "abort": {

--- a/custom_components/seatemperatures/translations/en.json
+++ b/custom_components/seatemperatures/translations/en.json
@@ -2,29 +2,24 @@
   "config": {
     "step": {
       "user": {
-        "title": "Select Continent",
-        "description": "Please select the continent for the area you want to monitor.",
+        "title": "Search Location",
+        "description": "Search SeaTemperatures.net for the location you want to monitor.",
         "data": {
-          "continent": "Continent"
+          "query": "Search"
         }
       },
-      "country": {
-        "title": "Select Country",
-        "description": "Please select the country the area is located in.",
+      "select": {
+        "title": "Select Location",
+        "description": "Choose the matching result for \"{query}\".",
         "data": {
-          "country": "Country"
-        }
-      },
-      "place": {
-        "title": "Select Place",
-        "description": "Please select the place you want to monitor.",
-        "data": {
-          "place": "Place"
+          "place": "Location"
         }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to seatemperatures.net. Please check your internet connection.",
+      "invalid_query": "Enter a location to search for.",
+      "no_results": "No SeaTemperatures.net locations matched that search.",
       "unknown": "Unexpected error."
     },
     "abort": {

--- a/custom_components/seatemperatures/translations/es.json
+++ b/custom_components/seatemperatures/translations/es.json
@@ -2,23 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "title": "Seleccionar Continente",
-        "description": "Por favor, seleccione el continente de la zona que desea monitorizar.",
-        "data": { "continent": "Continente" }
+        "title": "Buscar ubicación",
+        "description": "Busque en SeaTemperatures.net la ubicación que desea monitorizar.",
+        "data": { "query": "Búsqueda" }
       },
-      "country": {
-        "title": "Seleccionar País",
-        "description": "Por favor, seleccione el país donde se encuentra la zona.",
-        "data": { "country": "País" }
-      },
-      "place": {
-        "title": "Seleccionar Lugar",
-        "description": "Por favor, seleccione el lugar que desea monitorizar.",
+      "select": {
+        "title": "Seleccionar ubicación",
+        "description": "Elija el resultado correcto para \"{query}\".",
         "data": { "place": "Lugar" }
       }
     },
     "error": {
       "cannot_connect": "No se pudo conectar a seatemperatures.net. Por favor, compruebe su conexión a internet.",
+      "invalid_query": "Introduzca una ubicación para buscar.",
+      "no_results": "No se encontraron ubicaciones de SeaTemperatures.net para esa búsqueda.",
       "unknown": "Error inesperado."
     },
     "abort": {

--- a/custom_components/seatemperatures/translations/fr.json
+++ b/custom_components/seatemperatures/translations/fr.json
@@ -2,23 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "title": "Sélectionner le continent",
-        "description": "Veuillez sélectionner le continent de la zone que vous souhaitez surveiller.",
-        "data": { "continent": "Continent" }
+        "title": "Rechercher un lieu",
+        "description": "Recherchez sur SeaTemperatures.net le lieu que vous souhaitez surveiller.",
+        "data": { "query": "Recherche" }
       },
-      "country": {
-        "title": "Sélectionner le pays",
-        "description": "Veuillez sélectionner le pays où se trouve la zone.",
-        "data": { "country": "Pays" }
-      },
-      "place": {
+      "select": {
         "title": "Sélectionner le lieu",
-        "description": "Veuillez sélectionner le lieu que vous souhaitez surveiller.",
+        "description": "Choisissez le bon résultat pour \"{query}\".",
         "data": { "place": "Lieu" }
       }
     },
     "error": {
       "cannot_connect": "Échec de la connexion à seatemperatures.net. Veuillez vérifier votre connexion Internet.",
+      "invalid_query": "Saisissez un lieu à rechercher.",
+      "no_results": "Aucun lieu SeaTemperatures.net ne correspond à cette recherche.",
       "unknown": "Erreur inattendue."
     },
     "abort": {

--- a/custom_components/seatemperatures/translations/it.json
+++ b/custom_components/seatemperatures/translations/it.json
@@ -2,23 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "title": "Seleziona Continente",
-        "description": "Seleziona il continente della zona che vuoi monitorare.",
-        "data": { "continent": "Continente" }
+        "title": "Cerca località",
+        "description": "Cerca su SeaTemperatures.net la località che vuoi monitorare.",
+        "data": { "query": "Ricerca" }
       },
-      "country": {
-        "title": "Seleziona Paese",
-        "description": "Seleziona il paese in cui si trova la zona.",
-        "data": { "country": "Paese" }
-      },
-      "place": {
-        "title": "Seleziona Luogo",
-        "description": "Seleziona il luogo che vuoi monitorare.",
+      "select": {
+        "title": "Seleziona località",
+        "description": "Scegli il risultato corretto per \"{query}\".",
         "data": { "place": "Luogo" }
       }
     },
     "error": {
       "cannot_connect": "Impossibile connettersi a seatemperatures.net. Controlla la tua connessione internet.",
+      "invalid_query": "Inserisci una località da cercare.",
+      "no_results": "Nessuna località di SeaTemperatures.net corrisponde alla ricerca.",
       "unknown": "Errore imprevisto."
     },
     "abort": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ dev = [
 
 [tool.setuptools.packages.find]
 include = ["custom_components*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

This updates the integration to work with the current SeaTemperatures.net site structure.

The previous endpoints used by the integration are no longer suitable for current location lookup and temperature retrieval, so this change moves the backend to the current path-based model used by SeaTemperatures.net.

## Changes

- switched location discovery to `https://seatemperatures.net/api/search/?q=...`
- switched temperature retrieval from legacy `place_id` API calls to location pages like `https://seatemperatures.net/<path>/`
- added parsing for the current location pages and embedded chart payload
- updated the config flow from continent/country/place selection to search + select
- stored `path`, `place`, `country`, `area`, and `continent` in config entries
- added migration logic for legacy entries that still only have `place_id`
- kept the returned payload shape compatible with the existing sensor logic where possible
- avoided fabricating values that are no longer exposed by the site, such as `last_year`
- added tests and HTML fixtures covering page parsing, search result normalization, legacy migration, and the updated config flow

## Migration

Legacy `place_id` entries are migrated by resolving the old ID through `https://seatemperatures.net/api/map-locations.json` and then storing the current location `path`.

If a legacy `place_id` can no longer be resolved by SeaTemperatures.net, migration fails cleanly instead of creating a broken entry.

## Testing

I tested this locally with:

- `python -m compileall .`
- `.venv/bin/pytest custom_components/seatemperatures/tests`
- `.venv/bin/ruff check .`
- `npm run check-format`
- `npm run lint`
- `npm run test`

I also validated the integration against a real Home Assistant instance by:

- adding `Copenhagen` through the new search flow
- confirming the entity was created and updated successfully
- confirming expected attributes like `yesterday`, `last_week`, `average_*`, `charts.last_thirty`, and `path`
- adding and removing another location (`Stockholm`) to verify the updated flow end to end

## Additional note

I used AI assistance while developing this patch, but I reviewed the changes and validated the behavior locally and against a real Home Assistant instance before opening this PR.
